### PR TITLE
add a special case handling for eq predicate

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.2.0rc13"
+__extension_version__ = "0.2.0rc14"
 __extension_name__ = "pytket-qir"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.2.0rc14 (July 2023)
+---------------------
+* add simplification for RangePredicate in case of equal bounds
+* update pytket requirement to 1.17
+
 0.2.0rc13 (June 2023)
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.16",
+        "pytket ~= 1.17",
         "pyqir == 0.8.2",
         "pyqir-generator == 0.7.0",
         "pyqir-evaluator == 0.7.0",

--- a/tests/conditional_test.py
+++ b/tests/conditional_test.py
@@ -16,7 +16,7 @@ from utilities import check_qir_result  # type: ignore
 
 from pytket.qir.conversion.api import pytket_to_qir, QIRFormat
 
-from pytket.circuit import Circuit, Qubit, if_not_bit, Bit, OpType  # type: ignore
+from pytket.circuit import Circuit, Qubit, if_not_bit, Bit, OpType, reg_eq  # type: ignore
 
 
 def test_pytket_qir_conditional() -> None:
@@ -151,9 +151,30 @@ def test_pytket_qir_conditional_6() -> None:
     check_qir_result(result, "test_pytket_qir_conditional_6")
 
 
+def test_pytket_qir_conditional_7() -> None:
+
+    circ = Circuit(7, name="testcirc")
+
+    syn = circ.add_c_register("syn", 4)
+
+    circ.X(0, condition=reg_eq(syn, 1))
+    circ.X(0, condition=reg_eq(syn, 2))
+    circ.X(0, condition=reg_eq(syn, 2))
+    circ.X(0, condition=reg_eq(syn, 3))
+    circ.X(0, condition=reg_eq(syn, 4))
+    circ.X(0, condition=reg_eq(syn, 4))
+
+    result = pytket_to_qir(
+        circ, name="test_pytket_qir_conditional_7", qir_format=QIRFormat.STRING
+    )
+
+    check_qir_result(result, "test_pytket_qir_conditional_7")
+
+
 if __name__ == "__main__":
     test_pytket_qir_conditional()
     test_pytket_qir_conditional_ii()
     test_pytket_qir_conditional_iii()
     test_pytket_qir_conditional_iv()
     test_pytket_qir_conditional_6()
+    test_pytket_qir_conditional_7()

--- a/tests/qir/test_pytket_qir_14.ll
+++ b/tests/qir/test_pytket_qir_14.ll
@@ -72,28 +72,24 @@ entry:
   call void @set_all_bits_in_reg(i64 %0, i64 %17)
   %18 = lshr i64 %0, 1
   call void @set_all_bits_in_reg(i64 %1, i64 %18)
-  %19 = icmp sgt i64 1, %0
-  %20 = icmp sgt i64 %0, 1
-  %21 = and i1 %19, %20
-  call void @set_one_bit_in_reg(i64 %3, i64 4, i1 %21)
-  %22 = icmp sgt i64 2, %0
-  %23 = icmp sgt i64 %0, 4294967295
-  %24 = and i1 %22, %23
-  call void @set_one_bit_in_reg(i64 %3, i64 5, i1 %24)
-  %25 = icmp sgt i64 0, %0
-  %26 = icmp sgt i64 %0, 0
-  %27 = and i1 %25, %26
-  call void @set_one_bit_in_reg(i64 %3, i64 6, i1 %27)
-  %28 = icmp sgt i64 1, %0
-  %29 = icmp sgt i64 %0, 4294967295
-  %30 = and i1 %28, %29
-  call void @set_one_bit_in_reg(i64 %3, i64 7, i1 %30)
-  %31 = icmp sgt i64 0, %0
-  %32 = icmp sgt i64 %0, 1
-  %33 = and i1 %31, %32
-  call void @set_one_bit_in_reg(i64 %3, i64 8, i1 %33)
-  %34 = call i1 @read_bit_from_reg(i64 %0, i64 0)
-  br i1 %34, label %then, label %else
+  %19 = icmp eq i64 1, %0
+  call void @set_one_bit_in_reg(i64 %3, i64 4, i1 %19)
+  %20 = icmp sgt i64 2, %0
+  %21 = icmp sgt i64 %0, 4294967295
+  %22 = and i1 %20, %21
+  call void @set_one_bit_in_reg(i64 %3, i64 5, i1 %22)
+  %23 = icmp eq i64 0, %0
+  call void @set_one_bit_in_reg(i64 %3, i64 6, i1 %23)
+  %24 = icmp sgt i64 1, %0
+  %25 = icmp sgt i64 %0, 4294967295
+  %26 = and i1 %24, %25
+  call void @set_one_bit_in_reg(i64 %3, i64 7, i1 %26)
+  %27 = icmp sgt i64 0, %0
+  %28 = icmp sgt i64 %0, 1
+  %29 = and i1 %27, %28
+  call void @set_one_bit_in_reg(i64 %3, i64 8, i1 %29)
+  %30 = call i1 @read_bit_from_reg(i64 %0, i64 0)
+  br i1 %30, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
@@ -102,30 +98,24 @@ else:                                             ; preds = %entry
   br label %continue
 
 continue:                                         ; preds = %else, %then
-  %35 = call i1 @read_bit_from_reg(i64 %0, i64 0)
-  %36 = call i1 @read_bit_from_reg(i64 %1, i64 0)
-  %37 = xor i1 %35, %36
-  call void @set_one_bit_in_reg(i64 %3, i64 1, i1 %37)
-  %38 = xor i64 %0, %1
-  call void @set_all_bits_in_reg(i64 %4, i64 %38)
-  %39 = and i64 %0, %1
-  call void @set_all_bits_in_reg(i64 %5, i64 %39)
-  %40 = or i64 %0, %1
-  call void @set_all_bits_in_reg(i64 %6, i64 %40)
-  %41 = icmp sgt i64 1, %4
-  %42 = icmp sgt i64 %4, 1
-  %43 = and i1 %41, %42
-  call void @set_one_bit_in_reg(i64 %3, i64 0, i1 %43)
-  %44 = icmp sgt i64 1, %5
-  %45 = icmp sgt i64 %5, 1
-  %46 = and i1 %44, %45
-  call void @set_one_bit_in_reg(i64 %3, i64 2, i1 %46)
-  %47 = icmp sgt i64 1, %6
-  %48 = icmp sgt i64 %6, 1
-  %49 = and i1 %47, %48
-  call void @set_one_bit_in_reg(i64 %3, i64 3, i1 %49)
-  %50 = call i1 @read_bit_from_reg(i64 %3, i64 0)
-  br i1 %50, label %then1, label %else2
+  %31 = call i1 @read_bit_from_reg(i64 %0, i64 0)
+  %32 = call i1 @read_bit_from_reg(i64 %1, i64 0)
+  %33 = xor i1 %31, %32
+  call void @set_one_bit_in_reg(i64 %3, i64 1, i1 %33)
+  %34 = xor i64 %0, %1
+  call void @set_all_bits_in_reg(i64 %4, i64 %34)
+  %35 = and i64 %0, %1
+  call void @set_all_bits_in_reg(i64 %5, i64 %35)
+  %36 = or i64 %0, %1
+  call void @set_all_bits_in_reg(i64 %6, i64 %36)
+  %37 = icmp eq i64 1, %4
+  call void @set_one_bit_in_reg(i64 %3, i64 0, i1 %37)
+  %38 = icmp eq i64 1, %5
+  call void @set_one_bit_in_reg(i64 %3, i64 2, i1 %38)
+  %39 = icmp eq i64 1, %6
+  call void @set_one_bit_in_reg(i64 %3, i64 3, i1 %39)
+  %40 = call i1 @read_bit_from_reg(i64 %3, i64 0)
+  br i1 %40, label %then1, label %else2
 
 then1:                                            ; preds = %continue
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -135,8 +125,8 @@ else2:                                            ; preds = %continue
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
-  %51 = call i1 @read_bit_from_reg(i64 %3, i64 1)
-  br i1 %51, label %then4, label %else5
+  %41 = call i1 @read_bit_from_reg(i64 %3, i64 1)
+  br i1 %41, label %then4, label %else5
 
 then4:                                            ; preds = %continue3
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -146,8 +136,8 @@ else5:                                            ; preds = %continue3
   br label %continue6
 
 continue6:                                        ; preds = %else5, %then4
-  %52 = call i1 @read_bit_from_reg(i64 %3, i64 2)
-  br i1 %52, label %then7, label %else8
+  %42 = call i1 @read_bit_from_reg(i64 %3, i64 2)
+  br i1 %42, label %then7, label %else8
 
 then7:                                            ; preds = %continue6
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -157,8 +147,8 @@ else8:                                            ; preds = %continue6
   br label %continue9
 
 continue9:                                        ; preds = %else8, %then7
-  %53 = call i1 @read_bit_from_reg(i64 %3, i64 3)
-  br i1 %53, label %then10, label %else11
+  %43 = call i1 @read_bit_from_reg(i64 %3, i64 3)
+  br i1 %43, label %then10, label %else11
 
 then10:                                           ; preds = %continue9
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -168,8 +158,8 @@ else11:                                           ; preds = %continue9
   br label %continue12
 
 continue12:                                       ; preds = %else11, %then10
-  %54 = call i1 @read_bit_from_reg(i64 %0, i64 0)
-  br i1 %54, label %then13, label %else14
+  %44 = call i1 @read_bit_from_reg(i64 %0, i64 0)
+  br i1 %44, label %then13, label %else14
 
 then13:                                           ; preds = %continue12
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -179,8 +169,8 @@ else14:                                           ; preds = %continue12
   br label %continue15
 
 continue15:                                       ; preds = %else14, %then13
-  %55 = call i1 @read_bit_from_reg(i64 %3, i64 4)
-  br i1 %55, label %then16, label %else17
+  %45 = call i1 @read_bit_from_reg(i64 %3, i64 4)
+  br i1 %45, label %then16, label %else17
 
 then16:                                           ; preds = %continue15
   br label %continue18
@@ -190,8 +180,8 @@ else17:                                           ; preds = %continue15
   br label %continue18
 
 continue18:                                       ; preds = %else17, %then16
-  %56 = call i1 @read_bit_from_reg(i64 %0, i64 0)
-  br i1 %56, label %then19, label %else20
+  %46 = call i1 @read_bit_from_reg(i64 %0, i64 0)
+  br i1 %46, label %then19, label %else20
 
 then19:                                           ; preds = %continue18
   br label %continue21
@@ -201,8 +191,8 @@ else20:                                           ; preds = %continue18
   br label %continue21
 
 continue21:                                       ; preds = %else20, %then19
-  %57 = call i1 @read_bit_from_reg(i64 %3, i64 5)
-  br i1 %57, label %then22, label %else23
+  %47 = call i1 @read_bit_from_reg(i64 %3, i64 5)
+  br i1 %47, label %then22, label %else23
 
 then22:                                           ; preds = %continue21
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -212,8 +202,8 @@ else23:                                           ; preds = %continue21
   br label %continue24
 
 continue24:                                       ; preds = %else23, %then22
-  %58 = call i1 @read_bit_from_reg(i64 %3, i64 6)
-  br i1 %58, label %then25, label %else26
+  %48 = call i1 @read_bit_from_reg(i64 %3, i64 6)
+  br i1 %48, label %then25, label %else26
 
 then25:                                           ; preds = %continue24
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -223,8 +213,8 @@ else26:                                           ; preds = %continue24
   br label %continue27
 
 continue27:                                       ; preds = %else26, %then25
-  %59 = call i1 @read_bit_from_reg(i64 %3, i64 7)
-  br i1 %59, label %then28, label %else29
+  %49 = call i1 @read_bit_from_reg(i64 %3, i64 7)
+  br i1 %49, label %then28, label %else29
 
 then28:                                           ; preds = %continue27
   call void @__quantum__qis__x__body(%Qubit* null)
@@ -234,8 +224,8 @@ else29:                                           ; preds = %continue27
   br label %continue30
 
 continue30:                                       ; preds = %else29, %then28
-  %60 = call i1 @read_bit_from_reg(i64 %3, i64 8)
-  br i1 %60, label %then31, label %else32
+  %50 = call i1 @read_bit_from_reg(i64 %3, i64 8)
+  br i1 %50, label %then31, label %else32
 
 then31:                                           ; preds = %continue30
   call void @__quantum__qis__x__body(%Qubit* null)

--- a/tests/qir/test_pytket_qir_conditional_7.ll
+++ b/tests/qir/test_pytket_qir_conditional_7.ll
@@ -1,10 +1,10 @@
-; ModuleID = 'test_pytket_qir_rangepredicate'
-source_filename = "test_pytket_qir_rangepredicate"
+; ModuleID = 'test_pytket_qir_conditional_7'
+source_filename = "test_pytket_qir_conditional_7"
 
 %Qubit = type opaque
 %Result = type opaque
 
-@0 = internal constant [2 x i8] c"a\00"
+@0 = internal constant [4 x i8] c"syn\00"
 @1 = internal constant [15 x i8] c"tk_SCRATCH_BIT\00"
 
 define void @main() #0 {
@@ -13,82 +13,76 @@ entry:
   %1 = call i64 @reg2var(i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false)
   %2 = icmp eq i64 1, %0
   call void @set_one_bit_in_reg(i64 %1, i64 0, i1 %2)
-  %3 = icmp eq i64 1, %0
+  %3 = icmp eq i64 2, %0
   call void @set_one_bit_in_reg(i64 %1, i64 1, i1 %3)
-  %4 = icmp eq i64 0, %0
+  %4 = icmp eq i64 2, %0
   call void @set_one_bit_in_reg(i64 %1, i64 2, i1 %4)
-  %5 = icmp sgt i64 2, %0
-  %6 = icmp sgt i64 %0, 4294967295
-  %7 = and i1 %5, %6
-  call void @set_one_bit_in_reg(i64 %1, i64 3, i1 %7)
-  %8 = icmp sgt i64 0, %0
-  %9 = icmp sgt i64 %0, 1
-  %10 = and i1 %8, %9
-  call void @set_one_bit_in_reg(i64 %1, i64 4, i1 %10)
-  %11 = icmp sgt i64 1, %0
-  %12 = icmp sgt i64 %0, 4294967295
-  %13 = and i1 %11, %12
-  call void @set_one_bit_in_reg(i64 %1, i64 5, i1 %13)
-  %14 = call i1 @read_bit_from_reg(i64 %1, i64 0)
-  br i1 %14, label %then, label %else
+  %5 = icmp eq i64 3, %0
+  call void @set_one_bit_in_reg(i64 %1, i64 3, i1 %5)
+  %6 = icmp eq i64 4, %0
+  call void @set_one_bit_in_reg(i64 %1, i64 4, i1 %6)
+  %7 = icmp eq i64 4, %0
+  call void @set_one_bit_in_reg(i64 %1, i64 5, i1 %7)
+  %8 = call i1 @read_bit_from_reg(i64 %1, i64 0)
+  br i1 %8, label %then, label %else
 
 then:                                             ; preds = %entry
-  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue
 
 else:                                             ; preds = %entry
   br label %continue
 
 continue:                                         ; preds = %else, %then
-  %15 = call i1 @read_bit_from_reg(i64 %1, i64 1)
-  br i1 %15, label %then1, label %else2
+  %9 = call i1 @read_bit_from_reg(i64 %1, i64 1)
+  br i1 %9, label %then1, label %else2
 
 then1:                                            ; preds = %continue
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue3
 
 else2:                                            ; preds = %continue
-  call void @__quantum__qis__h__body(%Qubit* null)
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
-  %16 = call i1 @read_bit_from_reg(i64 %1, i64 2)
-  br i1 %16, label %then4, label %else5
+  %10 = call i1 @read_bit_from_reg(i64 %1, i64 2)
+  br i1 %10, label %then4, label %else5
 
 then4:                                            ; preds = %continue3
-  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue6
 
 else5:                                            ; preds = %continue3
   br label %continue6
 
 continue6:                                        ; preds = %else5, %then4
-  %17 = call i1 @read_bit_from_reg(i64 %1, i64 3)
-  br i1 %17, label %then7, label %else8
+  %11 = call i1 @read_bit_from_reg(i64 %1, i64 3)
+  br i1 %11, label %then7, label %else8
 
 then7:                                            ; preds = %continue6
-  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue9
 
 else8:                                            ; preds = %continue6
   br label %continue9
 
 continue9:                                        ; preds = %else8, %then7
-  %18 = call i1 @read_bit_from_reg(i64 %1, i64 4)
-  br i1 %18, label %then10, label %else11
+  %12 = call i1 @read_bit_from_reg(i64 %1, i64 4)
+  br i1 %12, label %then10, label %else11
 
 then10:                                           ; preds = %continue9
-  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue12
 
 else11:                                           ; preds = %continue9
   br label %continue12
 
 continue12:                                       ; preds = %else11, %then10
-  %19 = call i1 @read_bit_from_reg(i64 %1, i64 5)
-  br i1 %19, label %then13, label %else14
+  %13 = call i1 @read_bit_from_reg(i64 %1, i64 5)
+  br i1 %13, label %then13, label %else14
 
 then13:                                           ; preds = %continue12
-  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__x__body(%Qubit* null)
   br label %continue15
 
 else14:                                           ; preds = %continue12
@@ -96,7 +90,7 @@ else14:                                           ; preds = %continue12
 
 continue15:                                       ; preds = %else14, %then13
   call void @__quantum__rt__tuple_start_record_output()
-  call void @__quantum__rt__int_record_output(i64 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
   call void @__quantum__rt__int_record_output(i64 %1, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @1, i32 0, i32 0))
   call void @__quantum__rt__tuple_end_record_output()
   ret void
@@ -118,9 +112,9 @@ declare void @__quantum__rt__tuple_start_record_output()
 
 declare void @__quantum__rt__tuple_end_record_output()
 
-declare void @__quantum__qis__h__body(%Qubit*)
+declare void @__quantum__qis__x__body(%Qubit*)
 
-attributes #0 = { "entry_point" "num_required_qubits"="3" "num_required_results"="3" "output_labeling_schema" "qir_profiles"="custom" }
+attributes #0 = { "entry_point" "num_required_qubits"="7" "num_required_results"="7" "output_labeling_schema" "qir_profiles"="custom" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 


### PR DESCRIPTION
This PR is adding a special case handling for all Rangepredicates were the two arguments are identical.
When the lower and the upper bound of the predicate are identical the op should be translated to one `pyqir.IntPredicate.EQ` and not to three instructions like it is done for all other cases.

