### PR TITLE
add trunc zext

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.13.0rc0"
+__extension_version__ = "0.13.0rc1"
 __extension_name__ = "pytket-qir"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,10 @@
 Changelog
 ~~~~~~~~~
 
-0.13.0rc0 (August 2024)
+0.13.0rc1 (August 2024)
 -----------------------
 
+* Updated pyqir version requirement to 0.10.4.
 * Add option to generate profile compatible QIR
 
 0.12.0 (July 2024)

--- a/pytket/qir/conversion/pconversion.py
+++ b/pytket/qir/conversion/pconversion.py
@@ -325,7 +325,7 @@ class PQirGenerator:
             raise ValueError(f"{reg_name} is not a valid register")
         return self.ssa_vars[reg_name]
 
-    def set_ssa_vars(self, reg_name: str, ssa_i64: Value, trunc=True) -> None:
+    def set_ssa_vars(self, reg_name: str, ssa_i64: Value, trunc: bool=True) -> None:
         if reg_name not in self.ssa_vars:
             raise ValueError(f"{reg_name} is not a valid register")
         if trunc and self.creg_size[reg_name] != self.int_size:

--- a/pytket/qir/conversion/pconversion.py
+++ b/pytket/qir/conversion/pconversion.py
@@ -325,7 +325,7 @@ class PQirGenerator:
             raise ValueError(f"{reg_name} is not a valid register")
         return self.ssa_vars[reg_name]
 
-    def set_ssa_vars(self, reg_name: str, ssa_i64: Value, trunc: bool=True) -> None:
+    def set_ssa_vars(self, reg_name: str, ssa_i64: Value, trunc: bool = True) -> None:
         if reg_name not in self.ssa_vars:
             raise ValueError(f"{reg_name} is not a valid register")
         if trunc and self.creg_size[reg_name] != self.int_size:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket >= 1.31.0",
-        "pyqir >= 0.10.3",
+        "pyqir >= 0.10.4",
     ],
     classifiers=[
         "Environment :: Console",

--- a/tests/qir/ptest_pytket_qir_14.ll
+++ b/tests/qir/ptest_pytket_qir_14.ll
@@ -447,11 +447,19 @@ sb_1_34:                                          ; preds = %entry_33
 entry_34:                                         ; preds = %sb_0_34, %sb_1_34
   %116 = phi i64 [ %114, %sb_0_34 ], [ %115, %sb_1_34 ]
   %117 = add i64 %76, %116
-  %118 = sub i64 %76, %116
-  %119 = shl i64 %76, 1
-  %120 = lshr i64 %119, 1
-  %121 = icmp eq i64 1, %119
-  br i1 %121, label %sb_1_35, label %sb_0_35
+  %118 = trunc i64 %117 to i10
+  %119 = zext i10 %118 to i64
+  %120 = sub i64 %76, %116
+  %121 = trunc i64 %120 to i10
+  %122 = zext i10 %121 to i64
+  %123 = shl i64 %76, 1
+  %124 = trunc i64 %123 to i8
+  %125 = zext i8 %124 to i64
+  %126 = lshr i64 %125, 1
+  %127 = trunc i64 %126 to i10
+  %128 = zext i10 %127 to i64
+  %129 = icmp eq i64 1, %125
+  br i1 %129, label %sb_1_35, label %sb_0_35
 
 sb_0_35:                                          ; preds = %entry_34
   br label %entry_35
@@ -460,238 +468,238 @@ sb_1_35:                                          ; preds = %entry_34
   br label %entry_35
 
 entry_35:                                         ; preds = %sb_0_35, %sb_1_35
-  %122 = phi i64 [ 0, %sb_0_35 ], [ 16, %sb_1_35 ]
-  %123 = icmp sgt i64 2, %119
-  %124 = icmp sgt i64 %119, -1
-  %125 = and i1 %123, %124
-  br i1 %125, label %sb_1_36, label %sb_0_36
+  %130 = phi i64 [ 0, %sb_0_35 ], [ 16, %sb_1_35 ]
+  %131 = icmp sgt i64 2, %125
+  %132 = icmp sgt i64 %125, -1
+  %133 = and i1 %131, %132
+  br i1 %133, label %sb_1_36, label %sb_0_36
 
 sb_0_36:                                          ; preds = %entry_35
-  %126 = and i64 9223372036854775775, %122
+  %134 = and i64 9223372036854775775, %130
   br label %entry_36
 
 sb_1_36:                                          ; preds = %entry_35
-  %127 = or i64 32, %122
+  %135 = or i64 32, %130
   br label %entry_36
 
 entry_36:                                         ; preds = %sb_0_36, %sb_1_36
-  %128 = phi i64 [ %126, %sb_0_36 ], [ %127, %sb_1_36 ]
-  %129 = icmp eq i64 0, %119
-  br i1 %129, label %sb_1_37, label %sb_0_37
+  %136 = phi i64 [ %134, %sb_0_36 ], [ %135, %sb_1_36 ]
+  %137 = icmp eq i64 0, %125
+  br i1 %137, label %sb_1_37, label %sb_0_37
 
 sb_0_37:                                          ; preds = %entry_36
-  %130 = and i64 9223372036854775743, %128
+  %138 = and i64 9223372036854775743, %136
   br label %entry_37
 
 sb_1_37:                                          ; preds = %entry_36
-  %131 = or i64 64, %128
+  %139 = or i64 64, %136
   br label %entry_37
 
 entry_37:                                         ; preds = %sb_0_37, %sb_1_37
-  %132 = phi i64 [ %130, %sb_0_37 ], [ %131, %sb_1_37 ]
-  %133 = icmp sgt i64 1, %119
-  %134 = icmp sgt i64 %119, -1
-  %135 = and i1 %133, %134
-  br i1 %135, label %sb_1_38, label %sb_0_38
+  %140 = phi i64 [ %138, %sb_0_37 ], [ %139, %sb_1_37 ]
+  %141 = icmp sgt i64 1, %125
+  %142 = icmp sgt i64 %125, -1
+  %143 = and i1 %141, %142
+  br i1 %143, label %sb_1_38, label %sb_0_38
 
 sb_0_38:                                          ; preds = %entry_37
-  %136 = and i64 9223372036854775679, %132
+  %144 = and i64 9223372036854775679, %140
   br label %entry_38
 
 sb_1_38:                                          ; preds = %entry_37
-  %137 = or i64 128, %132
+  %145 = or i64 128, %140
   br label %entry_38
 
 entry_38:                                         ; preds = %sb_0_38, %sb_1_38
-  %138 = phi i64 [ %136, %sb_0_38 ], [ %137, %sb_1_38 ]
-  %139 = icmp sgt i64 0, %119
-  %140 = icmp sgt i64 %119, 1
-  %141 = and i1 %139, %140
-  br i1 %141, label %sb_1_39, label %sb_0_39
+  %146 = phi i64 [ %144, %sb_0_38 ], [ %145, %sb_1_38 ]
+  %147 = icmp sgt i64 0, %125
+  %148 = icmp sgt i64 %125, 1
+  %149 = and i1 %147, %148
+  br i1 %149, label %sb_1_39, label %sb_0_39
 
 sb_0_39:                                          ; preds = %entry_38
-  %142 = and i64 9223372036854775551, %138
+  %150 = and i64 9223372036854775551, %146
   br label %entry_39
 
 sb_1_39:                                          ; preds = %entry_38
-  %143 = or i64 256, %138
+  %151 = or i64 256, %146
   br label %entry_39
 
 entry_39:                                         ; preds = %sb_0_39, %sb_1_39
-  %144 = phi i64 [ %142, %sb_0_39 ], [ %143, %sb_1_39 ]
-  %145 = and i64 1, %119
-  %146 = icmp eq i64 1, %145
-  br i1 %146, label %condb0, label %contb0
+  %152 = phi i64 [ %150, %sb_0_39 ], [ %151, %sb_1_39 ]
+  %153 = and i64 1, %125
+  %154 = icmp eq i64 1, %153
+  br i1 %154, label %condb0, label %contb0
 
 condb0:                                           ; preds = %entry_39
   br label %contb0
 
 contb0:                                           ; preds = %condb0, %entry_39
-  %147 = and i64 1, %119
-  %148 = icmp eq i64 1, %147
-  %149 = and i64 1, %120
-  %150 = icmp eq i64 1, %149
-  %151 = xor i1 %148, %150
-  br i1 %151, label %sb_1_40, label %sb_0_40
+  %155 = and i64 1, %125
+  %156 = icmp eq i64 1, %155
+  %157 = and i64 1, %128
+  %158 = icmp eq i64 1, %157
+  %159 = xor i1 %156, %158
+  br i1 %159, label %sb_1_40, label %sb_0_40
 
 sb_0_40:                                          ; preds = %contb0
-  %152 = and i64 9223372036854775805, %144
+  %160 = and i64 9223372036854775805, %152
   br label %contb0_40
 
 sb_1_40:                                          ; preds = %contb0
-  %153 = or i64 2, %144
+  %161 = or i64 2, %152
   br label %contb0_40
 
 contb0_40:                                        ; preds = %sb_0_40, %sb_1_40
-  %154 = phi i64 [ %152, %sb_0_40 ], [ %153, %sb_1_40 ]
-  %155 = xor i64 %119, %120
-  %156 = and i64 %119, %120
-  %157 = or i64 %119, %120
-  %158 = icmp eq i64 1, %155
-  br i1 %158, label %sb_1_41, label %sb_0_41
+  %162 = phi i64 [ %160, %sb_0_40 ], [ %161, %sb_1_40 ]
+  %163 = xor i64 %125, %128
+  %164 = and i64 %125, %128
+  %165 = or i64 %125, %128
+  %166 = icmp eq i64 1, %163
+  br i1 %166, label %sb_1_41, label %sb_0_41
 
 sb_0_41:                                          ; preds = %contb0_40
-  %159 = and i64 9223372036854775806, %154
+  %167 = and i64 9223372036854775806, %162
   br label %contb0_41
 
 sb_1_41:                                          ; preds = %contb0_40
-  %160 = or i64 1, %154
+  %168 = or i64 1, %162
   br label %contb0_41
 
 contb0_41:                                        ; preds = %sb_0_41, %sb_1_41
-  %161 = phi i64 [ %159, %sb_0_41 ], [ %160, %sb_1_41 ]
-  %162 = icmp eq i64 1, %156
-  br i1 %162, label %sb_1_42, label %sb_0_42
+  %169 = phi i64 [ %167, %sb_0_41 ], [ %168, %sb_1_41 ]
+  %170 = icmp eq i64 1, %164
+  br i1 %170, label %sb_1_42, label %sb_0_42
 
 sb_0_42:                                          ; preds = %contb0_41
-  %163 = and i64 9223372036854775803, %161
+  %171 = and i64 9223372036854775803, %169
   br label %contb0_42
 
 sb_1_42:                                          ; preds = %contb0_41
-  %164 = or i64 4, %161
+  %172 = or i64 4, %169
   br label %contb0_42
 
 contb0_42:                                        ; preds = %sb_0_42, %sb_1_42
-  %165 = phi i64 [ %163, %sb_0_42 ], [ %164, %sb_1_42 ]
-  %166 = icmp eq i64 1, %157
-  br i1 %166, label %sb_1_43, label %sb_0_43
+  %173 = phi i64 [ %171, %sb_0_42 ], [ %172, %sb_1_42 ]
+  %174 = icmp eq i64 1, %165
+  br i1 %174, label %sb_1_43, label %sb_0_43
 
 sb_0_43:                                          ; preds = %contb0_42
-  %167 = and i64 9223372036854775799, %165
+  %175 = and i64 9223372036854775799, %173
   br label %contb0_43
 
 sb_1_43:                                          ; preds = %contb0_42
-  %168 = or i64 8, %165
+  %176 = or i64 8, %173
   br label %contb0_43
 
 contb0_43:                                        ; preds = %sb_0_43, %sb_1_43
-  %169 = phi i64 [ %167, %sb_0_43 ], [ %168, %sb_1_43 ]
-  %170 = and i64 1, %169
-  %171 = icmp eq i64 1, %170
-  br i1 %171, label %condb1, label %contb1
+  %177 = phi i64 [ %175, %sb_0_43 ], [ %176, %sb_1_43 ]
+  %178 = and i64 1, %177
+  %179 = icmp eq i64 1, %178
+  br i1 %179, label %condb1, label %contb1
 
 condb1:                                           ; preds = %contb0_43
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb1
 
 contb1:                                           ; preds = %condb1, %contb0_43
-  %172 = and i64 2, %169
-  %173 = icmp eq i64 2, %172
-  br i1 %173, label %condb2, label %contb2
+  %180 = and i64 2, %177
+  %181 = icmp eq i64 2, %180
+  br i1 %181, label %condb2, label %contb2
 
 condb2:                                           ; preds = %contb1
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb2
 
 contb2:                                           ; preds = %condb2, %contb1
-  %174 = and i64 4, %169
-  %175 = icmp eq i64 4, %174
-  br i1 %175, label %condb3, label %contb3
+  %182 = and i64 4, %177
+  %183 = icmp eq i64 4, %182
+  br i1 %183, label %condb3, label %contb3
 
 condb3:                                           ; preds = %contb2
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb3
 
 contb3:                                           ; preds = %condb3, %contb2
-  %176 = and i64 8, %169
-  %177 = icmp eq i64 8, %176
-  br i1 %177, label %condb4, label %contb4
+  %184 = and i64 8, %177
+  %185 = icmp eq i64 8, %184
+  br i1 %185, label %condb4, label %contb4
 
 condb4:                                           ; preds = %contb3
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb4
 
 contb4:                                           ; preds = %condb4, %contb3
-  %178 = and i64 1, %119
-  %179 = icmp eq i64 1, %178
-  br i1 %179, label %condb5, label %contb5
+  %186 = and i64 1, %125
+  %187 = icmp eq i64 1, %186
+  br i1 %187, label %condb5, label %contb5
 
 condb5:                                           ; preds = %contb4
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb5
 
 contb5:                                           ; preds = %condb5, %contb4
-  %180 = and i64 16, %169
-  %181 = icmp eq i64 16, %180
-  br i1 %181, label %contb6, label %condb6
+  %188 = and i64 16, %177
+  %189 = icmp eq i64 16, %188
+  br i1 %189, label %contb6, label %condb6
 
 condb6:                                           ; preds = %contb5
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb6
 
 contb6:                                           ; preds = %condb6, %contb5
-  %182 = and i64 1, %119
-  %183 = icmp eq i64 1, %182
-  br i1 %183, label %contb7, label %condb7
+  %190 = and i64 1, %125
+  %191 = icmp eq i64 1, %190
+  br i1 %191, label %contb7, label %condb7
 
 condb7:                                           ; preds = %contb6
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb7
 
 contb7:                                           ; preds = %condb7, %contb6
-  %184 = and i64 32, %169
-  %185 = icmp eq i64 32, %184
-  br i1 %185, label %condb8, label %contb8
+  %192 = and i64 32, %177
+  %193 = icmp eq i64 32, %192
+  br i1 %193, label %condb8, label %contb8
 
 condb8:                                           ; preds = %contb7
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb8
 
 contb8:                                           ; preds = %condb8, %contb7
-  %186 = and i64 64, %169
-  %187 = icmp eq i64 64, %186
-  br i1 %187, label %condb9, label %contb9
+  %194 = and i64 64, %177
+  %195 = icmp eq i64 64, %194
+  br i1 %195, label %condb9, label %contb9
 
 condb9:                                           ; preds = %contb8
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb9
 
 contb9:                                           ; preds = %condb9, %contb8
-  %188 = and i64 128, %169
-  %189 = icmp eq i64 128, %188
-  br i1 %189, label %condb10, label %contb10
+  %196 = and i64 128, %177
+  %197 = icmp eq i64 128, %196
+  br i1 %197, label %condb10, label %contb10
 
 condb10:                                          ; preds = %contb9
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb10
 
 contb10:                                          ; preds = %condb10, %contb9
-  %190 = and i64 256, %169
-  %191 = icmp eq i64 256, %190
-  br i1 %191, label %condb11, label %contb11
+  %198 = and i64 256, %177
+  %199 = icmp eq i64 256, %198
+  br i1 %199, label %condb11, label %contb11
 
 condb11:                                          ; preds = %contb10
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb11
 
 contb11:                                          ; preds = %condb11, %contb10
-  call void @__quantum__rt__int_record_output(i64 %119, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %120, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %118, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %169, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @3, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %155, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %156, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @5, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %157, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %125, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %128, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %122, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %177, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @3, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %163, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @4, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %164, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @5, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %165, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0))
   ret void
 }
 

--- a/tests/qir/ptest_pytket_qir_14_b.ll
+++ b/tests/qir/ptest_pytket_qir_14_b.ll
@@ -1623,11 +1623,19 @@ sb_1_128:                                         ; preds = %entry_127
 entry_128:                                        ; preds = %sb_0_128, %sb_1_128
   %446 = phi i64 [ %444, %sb_0_128 ], [ %445, %sb_1_128 ]
   %447 = add i64 %286, %446
-  %448 = sub i64 %286, %446
-  %449 = shl i64 %286, 1
-  %450 = lshr i64 %449, 1
-  %451 = icmp eq i64 1, %449
-  br i1 %451, label %sb_1_129, label %sb_0_129
+  %448 = trunc i64 %447 to i32
+  %449 = zext i32 %448 to i64
+  %450 = sub i64 %286, %446
+  %451 = trunc i64 %450 to i32
+  %452 = zext i32 %451 to i64
+  %453 = shl i64 %286, 1
+  %454 = trunc i64 %453 to i32
+  %455 = zext i32 %454 to i64
+  %456 = lshr i64 %455, 1
+  %457 = trunc i64 %456 to i32
+  %458 = zext i32 %457 to i64
+  %459 = icmp eq i64 1, %455
+  br i1 %459, label %sb_1_129, label %sb_0_129
 
 sb_0_129:                                         ; preds = %entry_128
   br label %entry_129
@@ -1636,238 +1644,238 @@ sb_1_129:                                         ; preds = %entry_128
   br label %entry_129
 
 entry_129:                                        ; preds = %sb_0_129, %sb_1_129
-  %452 = phi i64 [ 0, %sb_0_129 ], [ 16, %sb_1_129 ]
-  %453 = icmp sgt i64 2, %449
-  %454 = icmp sgt i64 %449, -1
-  %455 = and i1 %453, %454
-  br i1 %455, label %sb_1_130, label %sb_0_130
+  %460 = phi i64 [ 0, %sb_0_129 ], [ 16, %sb_1_129 ]
+  %461 = icmp sgt i64 2, %455
+  %462 = icmp sgt i64 %455, -1
+  %463 = and i1 %461, %462
+  br i1 %463, label %sb_1_130, label %sb_0_130
 
 sb_0_130:                                         ; preds = %entry_129
-  %456 = and i64 9223372036854775775, %452
+  %464 = and i64 9223372036854775775, %460
   br label %entry_130
 
 sb_1_130:                                         ; preds = %entry_129
-  %457 = or i64 32, %452
+  %465 = or i64 32, %460
   br label %entry_130
 
 entry_130:                                        ; preds = %sb_0_130, %sb_1_130
-  %458 = phi i64 [ %456, %sb_0_130 ], [ %457, %sb_1_130 ]
-  %459 = icmp eq i64 0, %449
-  br i1 %459, label %sb_1_131, label %sb_0_131
+  %466 = phi i64 [ %464, %sb_0_130 ], [ %465, %sb_1_130 ]
+  %467 = icmp eq i64 0, %455
+  br i1 %467, label %sb_1_131, label %sb_0_131
 
 sb_0_131:                                         ; preds = %entry_130
-  %460 = and i64 9223372036854775743, %458
+  %468 = and i64 9223372036854775743, %466
   br label %entry_131
 
 sb_1_131:                                         ; preds = %entry_130
-  %461 = or i64 64, %458
+  %469 = or i64 64, %466
   br label %entry_131
 
 entry_131:                                        ; preds = %sb_0_131, %sb_1_131
-  %462 = phi i64 [ %460, %sb_0_131 ], [ %461, %sb_1_131 ]
-  %463 = icmp sgt i64 1, %449
-  %464 = icmp sgt i64 %449, -1
-  %465 = and i1 %463, %464
-  br i1 %465, label %sb_1_132, label %sb_0_132
+  %470 = phi i64 [ %468, %sb_0_131 ], [ %469, %sb_1_131 ]
+  %471 = icmp sgt i64 1, %455
+  %472 = icmp sgt i64 %455, -1
+  %473 = and i1 %471, %472
+  br i1 %473, label %sb_1_132, label %sb_0_132
 
 sb_0_132:                                         ; preds = %entry_131
-  %466 = and i64 9223372036854775679, %462
+  %474 = and i64 9223372036854775679, %470
   br label %entry_132
 
 sb_1_132:                                         ; preds = %entry_131
-  %467 = or i64 128, %462
+  %475 = or i64 128, %470
   br label %entry_132
 
 entry_132:                                        ; preds = %sb_0_132, %sb_1_132
-  %468 = phi i64 [ %466, %sb_0_132 ], [ %467, %sb_1_132 ]
-  %469 = icmp sgt i64 0, %449
-  %470 = icmp sgt i64 %449, 1
-  %471 = and i1 %469, %470
-  br i1 %471, label %sb_1_133, label %sb_0_133
+  %476 = phi i64 [ %474, %sb_0_132 ], [ %475, %sb_1_132 ]
+  %477 = icmp sgt i64 0, %455
+  %478 = icmp sgt i64 %455, 1
+  %479 = and i1 %477, %478
+  br i1 %479, label %sb_1_133, label %sb_0_133
 
 sb_0_133:                                         ; preds = %entry_132
-  %472 = and i64 9223372036854775551, %468
+  %480 = and i64 9223372036854775551, %476
   br label %entry_133
 
 sb_1_133:                                         ; preds = %entry_132
-  %473 = or i64 256, %468
+  %481 = or i64 256, %476
   br label %entry_133
 
 entry_133:                                        ; preds = %sb_0_133, %sb_1_133
-  %474 = phi i64 [ %472, %sb_0_133 ], [ %473, %sb_1_133 ]
-  %475 = and i64 1, %449
-  %476 = icmp eq i64 1, %475
-  br i1 %476, label %condb0, label %contb0
+  %482 = phi i64 [ %480, %sb_0_133 ], [ %481, %sb_1_133 ]
+  %483 = and i64 1, %455
+  %484 = icmp eq i64 1, %483
+  br i1 %484, label %condb0, label %contb0
 
 condb0:                                           ; preds = %entry_133
   br label %contb0
 
 contb0:                                           ; preds = %condb0, %entry_133
-  %477 = and i64 1, %449
-  %478 = icmp eq i64 1, %477
-  %479 = and i64 1, %450
-  %480 = icmp eq i64 1, %479
-  %481 = xor i1 %478, %480
-  br i1 %481, label %sb_1_134, label %sb_0_134
+  %485 = and i64 1, %455
+  %486 = icmp eq i64 1, %485
+  %487 = and i64 1, %458
+  %488 = icmp eq i64 1, %487
+  %489 = xor i1 %486, %488
+  br i1 %489, label %sb_1_134, label %sb_0_134
 
 sb_0_134:                                         ; preds = %contb0
-  %482 = and i64 9223372036854775805, %474
+  %490 = and i64 9223372036854775805, %482
   br label %contb0_134
 
 sb_1_134:                                         ; preds = %contb0
-  %483 = or i64 2, %474
+  %491 = or i64 2, %482
   br label %contb0_134
 
 contb0_134:                                       ; preds = %sb_0_134, %sb_1_134
-  %484 = phi i64 [ %482, %sb_0_134 ], [ %483, %sb_1_134 ]
-  %485 = xor i64 %449, %450
-  %486 = and i64 %449, %450
-  %487 = or i64 %449, %450
-  %488 = icmp eq i64 1, %485
-  br i1 %488, label %sb_1_135, label %sb_0_135
+  %492 = phi i64 [ %490, %sb_0_134 ], [ %491, %sb_1_134 ]
+  %493 = xor i64 %455, %458
+  %494 = and i64 %455, %458
+  %495 = or i64 %455, %458
+  %496 = icmp eq i64 1, %493
+  br i1 %496, label %sb_1_135, label %sb_0_135
 
 sb_0_135:                                         ; preds = %contb0_134
-  %489 = and i64 9223372036854775806, %484
+  %497 = and i64 9223372036854775806, %492
   br label %contb0_135
 
 sb_1_135:                                         ; preds = %contb0_134
-  %490 = or i64 1, %484
+  %498 = or i64 1, %492
   br label %contb0_135
 
 contb0_135:                                       ; preds = %sb_0_135, %sb_1_135
-  %491 = phi i64 [ %489, %sb_0_135 ], [ %490, %sb_1_135 ]
-  %492 = icmp eq i64 1, %486
-  br i1 %492, label %sb_1_136, label %sb_0_136
+  %499 = phi i64 [ %497, %sb_0_135 ], [ %498, %sb_1_135 ]
+  %500 = icmp eq i64 1, %494
+  br i1 %500, label %sb_1_136, label %sb_0_136
 
 sb_0_136:                                         ; preds = %contb0_135
-  %493 = and i64 9223372036854775803, %491
+  %501 = and i64 9223372036854775803, %499
   br label %contb0_136
 
 sb_1_136:                                         ; preds = %contb0_135
-  %494 = or i64 4, %491
+  %502 = or i64 4, %499
   br label %contb0_136
 
 contb0_136:                                       ; preds = %sb_0_136, %sb_1_136
-  %495 = phi i64 [ %493, %sb_0_136 ], [ %494, %sb_1_136 ]
-  %496 = icmp eq i64 1, %487
-  br i1 %496, label %sb_1_137, label %sb_0_137
+  %503 = phi i64 [ %501, %sb_0_136 ], [ %502, %sb_1_136 ]
+  %504 = icmp eq i64 1, %495
+  br i1 %504, label %sb_1_137, label %sb_0_137
 
 sb_0_137:                                         ; preds = %contb0_136
-  %497 = and i64 9223372036854775799, %495
+  %505 = and i64 9223372036854775799, %503
   br label %contb0_137
 
 sb_1_137:                                         ; preds = %contb0_136
-  %498 = or i64 8, %495
+  %506 = or i64 8, %503
   br label %contb0_137
 
 contb0_137:                                       ; preds = %sb_0_137, %sb_1_137
-  %499 = phi i64 [ %497, %sb_0_137 ], [ %498, %sb_1_137 ]
-  %500 = and i64 1, %499
-  %501 = icmp eq i64 1, %500
-  br i1 %501, label %condb1, label %contb1
+  %507 = phi i64 [ %505, %sb_0_137 ], [ %506, %sb_1_137 ]
+  %508 = and i64 1, %507
+  %509 = icmp eq i64 1, %508
+  br i1 %509, label %condb1, label %contb1
 
 condb1:                                           ; preds = %contb0_137
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb1
 
 contb1:                                           ; preds = %condb1, %contb0_137
-  %502 = and i64 2, %499
-  %503 = icmp eq i64 2, %502
-  br i1 %503, label %condb2, label %contb2
+  %510 = and i64 2, %507
+  %511 = icmp eq i64 2, %510
+  br i1 %511, label %condb2, label %contb2
 
 condb2:                                           ; preds = %contb1
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb2
 
 contb2:                                           ; preds = %condb2, %contb1
-  %504 = and i64 4, %499
-  %505 = icmp eq i64 4, %504
-  br i1 %505, label %condb3, label %contb3
+  %512 = and i64 4, %507
+  %513 = icmp eq i64 4, %512
+  br i1 %513, label %condb3, label %contb3
 
 condb3:                                           ; preds = %contb2
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb3
 
 contb3:                                           ; preds = %condb3, %contb2
-  %506 = and i64 8, %499
-  %507 = icmp eq i64 8, %506
-  br i1 %507, label %condb4, label %contb4
+  %514 = and i64 8, %507
+  %515 = icmp eq i64 8, %514
+  br i1 %515, label %condb4, label %contb4
 
 condb4:                                           ; preds = %contb3
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb4
 
 contb4:                                           ; preds = %condb4, %contb3
-  %508 = and i64 1, %449
-  %509 = icmp eq i64 1, %508
-  br i1 %509, label %condb5, label %contb5
+  %516 = and i64 1, %455
+  %517 = icmp eq i64 1, %516
+  br i1 %517, label %condb5, label %contb5
 
 condb5:                                           ; preds = %contb4
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb5
 
 contb5:                                           ; preds = %condb5, %contb4
-  %510 = and i64 16, %499
-  %511 = icmp eq i64 16, %510
-  br i1 %511, label %contb6, label %condb6
+  %518 = and i64 16, %507
+  %519 = icmp eq i64 16, %518
+  br i1 %519, label %contb6, label %condb6
 
 condb6:                                           ; preds = %contb5
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb6
 
 contb6:                                           ; preds = %condb6, %contb5
-  %512 = and i64 1, %449
-  %513 = icmp eq i64 1, %512
-  br i1 %513, label %contb7, label %condb7
+  %520 = and i64 1, %455
+  %521 = icmp eq i64 1, %520
+  br i1 %521, label %contb7, label %condb7
 
 condb7:                                           ; preds = %contb6
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb7
 
 contb7:                                           ; preds = %condb7, %contb6
-  %514 = and i64 32, %499
-  %515 = icmp eq i64 32, %514
-  br i1 %515, label %condb8, label %contb8
+  %522 = and i64 32, %507
+  %523 = icmp eq i64 32, %522
+  br i1 %523, label %condb8, label %contb8
 
 condb8:                                           ; preds = %contb7
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb8
 
 contb8:                                           ; preds = %condb8, %contb7
-  %516 = and i64 64, %499
-  %517 = icmp eq i64 64, %516
-  br i1 %517, label %condb9, label %contb9
+  %524 = and i64 64, %507
+  %525 = icmp eq i64 64, %524
+  br i1 %525, label %condb9, label %contb9
 
 condb9:                                           ; preds = %contb8
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb9
 
 contb9:                                           ; preds = %condb9, %contb8
-  %518 = and i64 128, %499
-  %519 = icmp eq i64 128, %518
-  br i1 %519, label %condb10, label %contb10
+  %526 = and i64 128, %507
+  %527 = icmp eq i64 128, %526
+  br i1 %527, label %condb10, label %contb10
 
 condb10:                                          ; preds = %contb9
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb10
 
 contb10:                                          ; preds = %condb10, %contb9
-  %520 = and i64 256, %499
-  %521 = icmp eq i64 256, %520
-  br i1 %521, label %condb11, label %contb11
+  %528 = and i64 256, %507
+  %529 = icmp eq i64 256, %528
+  br i1 %529, label %condb11, label %contb11
 
 condb11:                                          ; preds = %contb10
   call void @__quantum__qis__x__body(%Qubit* null)
   br label %contb11
 
 contb11:                                          ; preds = %condb11, %contb10
-  call void @__quantum__rt__int_record_output(i64 %449, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %450, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %448, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %499, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @3, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %485, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %486, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @5, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %487, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %455, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %458, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %452, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %507, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @3, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %493, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @4, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %494, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @5, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %495, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0))
   ret void
 }
 

--- a/tests/qir/ptest_pytket_qir_wasm_ii.ll
+++ b/tests/qir/ptest_pytket_qir_wasm_ii.ll
@@ -11,14 +11,20 @@ source_filename = "test_pytket_qir_wasm_ii"
 define void @main() #0 {
 entry:
   %0 = call i32 @multi(i32 0, i32 0)
-  %1 = call i32 @add_one(i32 %0)
-  call void @no_return(i32 %1)
+  %1 = trunc i32 %0 to i5
+  %2 = zext i5 %1 to i32
+  %3 = call i32 @add_one(i32 %2)
+  %4 = trunc i32 %3 to i5
+  %5 = zext i5 %4 to i32
+  call void @no_return(i32 %5)
   call void @init()
-  %2 = call i32 @no_parameters()
+  %6 = call i32 @no_parameters()
+  %7 = trunc i32 %6 to i5
+  %8 = zext i5 %7 to i32
   call void @__quantum__rt__int_record_output(i32 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @__quantum__rt__int_record_output(i32 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
   call void @__quantum__rt__int_record_output(i32 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i32 %2, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i32 %8, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @3, i32 0, i32 0))
   ret void
 }
 

--- a/tests/qir/ptest_pytket_qir_wasm_ii_64.ll
+++ b/tests/qir/ptest_pytket_qir_wasm_ii_64.ll
@@ -10,10 +10,14 @@ source_filename = "test_pytket_qir_wasm_ii_64"
 define void @main() #0 {
 entry:
   %0 = call i64 @add_something(i64 0)
-  %1 = call i64 @add_something(i64 %0)
+  %1 = trunc i64 %0 to i4
+  %2 = zext i4 %1 to i64
+  %3 = call i64 @add_something(i64 %2)
+  %4 = trunc i64 %3 to i4
+  %5 = zext i4 %4 to i64
   call void @__quantum__rt__int_record_output(i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @__quantum__rt__int_record_output(i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0))
   ret void
 }
 

--- a/tests/qir/ptest_pytket_qir_wasm_iii_64.ll
+++ b/tests/qir/ptest_pytket_qir_wasm_iii_64.ll
@@ -11,9 +11,11 @@ source_filename = "test_pytket_qir_wasm_iii_64"
 define void @main() #0 {
 entry:
   %0 = call i64 @add_something(i64 0)
+  %1 = trunc i64 %0 to i4
+  %2 = zext i4 %1 to i64
   call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  br i1 %1, label %sb_1_0, label %sb_0_0
+  %3 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  br i1 %3, label %sb_1_0, label %sb_0_0
 
 sb_0_0:                                           ; preds = %entry
   br label %entry_0
@@ -22,39 +24,41 @@ sb_1_0:                                           ; preds = %entry
   br label %entry_0
 
 entry_0:                                          ; preds = %sb_0_0, %sb_1_0
-  %2 = phi i64 [ 0, %sb_0_0 ], [ 1, %sb_1_0 ]
+  %4 = phi i64 [ 0, %sb_0_0 ], [ 1, %sb_1_0 ]
   call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %3 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  br i1 %3, label %sb_1_1, label %sb_0_1
+  %5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  br i1 %5, label %sb_1_1, label %sb_0_1
 
 sb_0_1:                                           ; preds = %entry_0
-  %4 = and i64 9223372036854775805, %2
+  %6 = and i64 9223372036854775805, %4
   br label %entry_1
 
 sb_1_1:                                           ; preds = %entry_0
-  %5 = or i64 2, %2
+  %7 = or i64 2, %4
   br label %entry_1
 
 entry_1:                                          ; preds = %sb_0_1, %sb_1_1
-  %6 = phi i64 [ %4, %sb_0_1 ], [ %5, %sb_1_1 ]
+  %8 = phi i64 [ %6, %sb_0_1 ], [ %7, %sb_1_1 ]
   call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-  %7 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
-  br i1 %7, label %sb_1_2, label %sb_0_2
+  %9 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
+  br i1 %9, label %sb_1_2, label %sb_0_2
 
 sb_0_2:                                           ; preds = %entry_1
-  %8 = and i64 9223372036854775803, %6
+  %10 = and i64 9223372036854775803, %8
   br label %entry_2
 
 sb_1_2:                                           ; preds = %entry_1
-  %9 = or i64 4, %6
+  %11 = or i64 4, %8
   br label %entry_2
 
 entry_2:                                          ; preds = %sb_0_2, %sb_1_2
-  %10 = phi i64 [ %8, %sb_0_2 ], [ %9, %sb_1_2 ]
-  %11 = call i64 @add_something(i64 %0)
-  call void @__quantum__rt__int_record_output(i64 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %12 = phi i64 [ %10, %sb_0_2 ], [ %11, %sb_1_2 ]
+  %13 = call i64 @add_something(i64 %2)
+  %14 = trunc i64 %13 to i4
+  %15 = zext i4 %14 to i64
+  call void @__quantum__rt__int_record_output(i64 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @__quantum__rt__int_record_output(i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %11, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0))
+  call void @__quantum__rt__int_record_output(i64 %15, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0))
   ret void
 }
 


### PR DESCRIPTION
# Description

Add zext and trunc operations to resize i64 to the register size after potentially setting bits outside of the register size.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
