### PR TITLE
Fix formatting in docstring.

### DIFF
--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -87,6 +87,10 @@ def pytket_to_qir(
         https://github.com/qir-alliance/qir-spec/tree/main/specification/under_development/profiles/Adaptive_Profile.md
       - Use ``QIRProfile.PYTKET`` for QIR with additional functions for classical
         registers.
+      - Use ``QIRProfile.AZUREBASE`` for the base profile with metadata for Azure
+        devices and ``array_record`` for output recording.
+      - Use ``QIRProfile.AZUREADAPTIVE`` for the adaptive profile with metadata for
+        Azure devices and bitwise recording of results via ``array_record``.
     """
 
     if cut_pytket_register:

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -76,16 +76,17 @@ def pytket_to_qir(
     :param cut_pytket_register: breaks up the internal scratch bit registers
       into smaller registers, default value false
     :param profile: generates QIR corresponding to the selected profile:
-        Use QIRProfile.BASE for the base profile, see:
-        https://github.com/qir-alliance/qir-spec/blob/main/specification/under_development/profiles/Base_Profile.md
-        Use QIRProfile.ADAPTIVE for the adaptive profile, see:
-        https://github.com/qir-alliance/qir-spec/tree/main/specification/under_development/profiles/Adaptive_Profile.md
-        Use QIRProfile.ADAPTIVE_CREGSIZE for the adaptive profile with additional
-        truncation operation to assure that integers matching the classical
-        registers have no unexpected set bits, see:
-        https://github.com/qir-alliance/qir-spec/tree/main/specification/under_development/profiles/Adaptive_Profile.md
-        Use QIRProfile.PYTKET for QIR with additonal function for classical registers.
 
+      - Use ``QIRProfile.BASE`` for the base profile. See:
+        https://github.com/qir-alliance/qir-spec/blob/main/specification/under_development/profiles/Base_Profile.md
+      - Use ``QIRProfile.ADAPTIVE`` for the adaptive profile. See:
+        https://github.com/qir-alliance/qir-spec/tree/main/specification/under_development/profiles/Adaptive_Profile.md
+      - Use ``QIRProfile.ADAPTIVE_CREGSIZE`` for the adaptive profile with additional
+        truncation operations to assure that integers matching the classical
+        registers have no unexpected set bits. See:
+        https://github.com/qir-alliance/qir-spec/tree/main/specification/under_development/profiles/Adaptive_Profile.md
+      - Use ``QIRProfile.PYTKET`` for QIR with additional functions for classical
+        registers.
     """
 
     if cut_pytket_register:


### PR DESCRIPTION
Fixes #199 .

Now looks like this:

![image](https://github.com/user-attachments/assets/537ae42f-2bad-43d7-8387-957908a47bad)
