### PR TITLE
Update pytket version requirement for 0.22.0 release

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.21.1"
+__extension_version__ = "0.22.0"
 __extension_name__ = "pytket-qir"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 ~~~~~~~~~
 
+0.22.0 (April 2025)
+-------------------
+
+* Update pytket minimium version requirement to 2.2.0.
+* Update pyqir minimium version requirement to 0.10.9.
+
 0.21.1 (March 2025)
 -------------------
 

--- a/pytket/qir/conversion/profileqirgenerator.py
+++ b/pytket/qir/conversion/profileqirgenerator.py
@@ -20,7 +20,6 @@ from pyqir import BasicBlock, Value
 from pytket.circuit import (
     Bit,
     BitRegister,
-    CircBox,
     Circuit,
     Command,
     Conditional,

--- a/pytket/qir/conversion/profileqirgenerator.py
+++ b/pytket/qir/conversion/profileqirgenerator.py
@@ -224,7 +224,7 @@ class AdaptiveProfileQirGenerator(AbstractQirGenerator):
             self.ssa_vars[reg_name] = [(ssa_var, self.active_block)]
             return ssa_var
         else:
-            return cast(Value, self.ssa_vars[reg_name])
+            return cast("Value", self.ssa_vars[reg_name])
 
     def _add_phi(self) -> None:
         """
@@ -281,7 +281,7 @@ class AdaptiveProfileQirGenerator(AbstractQirGenerator):
 
         if op.op.type == OpType.CircBox:
             conditional_circuit = self._decompose_conditional_circ_box(
-                cast(CircBox, op.op), command.args[op.width :]
+                cast("CircBox", op.op), command.args[op.width :]
             )
 
             condition_name = command.args[0].reg_name

--- a/pytket/qir/conversion/profileqirgenerator.py
+++ b/pytket/qir/conversion/profileqirgenerator.py
@@ -20,6 +20,7 @@ from pyqir import BasicBlock, Value
 from pytket.circuit import (
     Bit,
     BitRegister,
+    CircBox,
     Circuit,
     Command,
     Conditional,
@@ -278,9 +279,11 @@ class AdaptiveProfileQirGenerator(AbstractQirGenerator):
         self.active_block_list.append(condb)
         self.active_block_list.append(contb)
 
-        if op.op.type == OpType.CircBox:
+        inner_op = op.op
+        if inner_op.type == OpType.CircBox:
+            assert isinstance(inner_op, CircBox)
             conditional_circuit = self._decompose_conditional_circ_box(
-                cast("CircBox", op.op), command.args[op.width :]
+                inner_op, command.args[op.width :]
             )
 
             condition_name = command.args[0].reg_name

--- a/pytket/qir/conversion/pytketqirgenerator.py
+++ b/pytket/qir/conversion/pytketqirgenerator.py
@@ -187,7 +187,7 @@ class PytketQirGenerator(AbstractQirGenerator):
             self.ssa_vars[reg_name] = ssa_var
             return ssa_var
         else:
-            return cast(Value, self.ssa_vars[reg_name])  # type: ignore
+            return cast("Value", self.ssa_vars[reg_name])  # type: ignore
 
     def conv_conditional(self, command: Command, op: Conditional) -> None:
         condition_name = command.args[0].reg_name
@@ -204,7 +204,7 @@ class PytketQirGenerator(AbstractQirGenerator):
 
         if op.op.type == OpType.CircBox:
             conditional_circuit = self._decompose_conditional_circ_box(
-                cast(CircBox, op.op), command.args[op.width :]
+                cast("CircBox", op.op), command.args[op.width :]
             )
 
             condition_name = command.args[0].reg_name

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket >= 2.0.1",
-        "pyqir ~= 0.10.7",
+        "pytket >= 2.2.0",
+        "pyqir ~= 0.10.9",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
In order to get a release out I'd like to ignore the failing lint check. It turns out to be extremely difficult to satisfy pylint, ruff and mypy simultaneously here. Probably we should drop the pylint check and just use ruff instead, but I'd rather do that in another PR.