### PR TITLE
Add `ClassicalRegisterWidthError` to API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,4 +3,4 @@ API documentation
 
 .. automodule:: pytket.qir
     :special-members:
-    :members: pytket_to_qir, QIRFormat, QIRProfile
+    :members: pytket_to_qir, QIRFormat, QIRProfile, ClassicalRegisterWidthError

--- a/pytket/qir/conversion/__init__.py
+++ b/pytket/qir/conversion/__init__.py
@@ -14,4 +14,4 @@
 
 """Backends for processing pytket circuits with Quantinuum devices"""
 
-from .api import QIRFormat, QIRProfile, pytket_to_qir
+from .api import ClassicalRegisterWidthError, QIRFormat, QIRProfile, pytket_to_qir

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -57,6 +57,15 @@ class QIRProfile(Enum):
     PYTKET = 5
 
 
+class ClassicalRegisterWidthError(Exception):
+    """Error trying to convert a circuit with a classical register exceeding the maximum width"""
+
+    def __init__(self, width: int, max_width: int = 64) -> None:
+        super().__init__(
+            f"Classical register of width {width} exceeds maximum width ({max_width})."
+        )
+
+
 def pytket_to_qir(  # noqa: PLR0912, PLR0913
     circ: Circuit,
     name: str = "Generated from input pytket circuit",
@@ -224,10 +233,7 @@ def check_circuit(
 
     for creg in circuit.c_registers:
         if creg.size > int_type:
-            raise ValueError(
-                f"""classical registers must not have more than {int_type} bits, \
-you could try to set cut_pytket_register=True in the conversion""",
-            )
+            raise ClassicalRegisterWidthError(width=creg.size, max_width=int_type)
 
     set_circ_register = {creg.name for creg in circuit.c_registers}
     for b in {b.reg_name for b in circuit.bits}:

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -60,10 +60,15 @@ class QIRProfile(Enum):
 class ClassicalRegisterWidthError(Exception):
     """Error trying to convert a circuit with a classical register exceeding the maximum width"""
 
-    def __init__(self, width: int, max_width: int = 64) -> None:
-        super().__init__(
+    def __init__(
+        self, width: int, max_width: int = 64, hint: str | None = None
+    ) -> None:
+        msg = (
             f"Classical register of width {width} exceeds maximum width ({max_width})."
         )
+        if hint is not None:
+            msg += f" Hint: {hint}."
+        super().__init__(msg)
 
 
 def pytket_to_qir(  # noqa: PLR0912, PLR0913
@@ -233,7 +238,11 @@ def check_circuit(
 
     for creg in circuit.c_registers:
         if creg.size > int_type:
-            raise ClassicalRegisterWidthError(width=creg.size, max_width=int_type)
+            raise ClassicalRegisterWidthError(
+                width=creg.size,
+                max_width=int_type,
+                hint="try setting cut_pytket_register=True` when calling `pytket_to_qir()`",
+            )
 
     set_circ_register = {creg.name for creg in circuit.c_registers}
     for b in {b.reg_name for b in circuit.bits}:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -20,6 +20,7 @@ from utilities import run_qir_gen_and_check  # type: ignore
 from pytket.circuit import Bit, Circuit
 from pytket.passes import FlattenRelabelRegistersPass
 from pytket.qir.conversion.api import (
+    ClassicalRegisterWidthError,
     QIRFormat,
     check_circuit,
     pytket_to_qir,
@@ -67,7 +68,7 @@ def test_pytket_api_creg() -> None:
 
     circ.add_c_register("c2", 100)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ClassicalRegisterWidthError):
         pytket_to_qir(circ)
 
 

--- a/tests/conditional_test.py
+++ b/tests/conditional_test.py
@@ -28,7 +28,12 @@ from pytket.circuit import (
 )
 from pytket.circuit.clexpr import wired_clexpr_from_logic_exp
 from pytket.circuit.logic_exp import BitNot, BitWiseOp, create_bit_logic_exp
-from pytket.qir.conversion.api import QIRFormat, QIRProfile, pytket_to_qir
+from pytket.qir.conversion.api import (
+    ClassicalRegisterWidthError,
+    QIRFormat,
+    QIRProfile,
+    pytket_to_qir,
+)
 
 
 @pytest.mark.parametrize(
@@ -344,7 +349,7 @@ def test_pytket_qir_conditional_12(profile: QIRProfile) -> None:
         circ.X(0, condition=reg_eq(syn, 4))
         circ.X(0, condition=reg_eq(syn, 4))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ClassicalRegisterWidthError):
         pytket_to_qir(
             circ,
             name="ptest_pytket_qir_conditional_12",


### PR DESCRIPTION
In order to address https://github.com/CQCL/pytket-quantinuum/issues/589 .