### PR TITLE
Store potentially useful information in exception.

### DIFF
--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -63,6 +63,9 @@ class ClassicalRegisterWidthError(Exception):
     def __init__(
         self, width: int, max_width: int = 64, hint: str | None = None
     ) -> None:
+        self.width = width
+        self.max_width = max_width
+        self.hint = hint
         msg = (
             f"Classical register of width {width} exceeds maximum width ({max_width})."
         )


### PR DESCRIPTION
I realized belatedly that it would be helpful for callers to be able to access `width` and `max_width` from the exception.