### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -80,7 +80,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,5 +2,101 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.qir
-    :special-members:
-    :members: pytket_to_qir, QIRFormat, QIRProfile, ClassicalRegisterWidthError
+.. automodule:: pytket.qir._metadata
+.. automodule:: pytket.qir.conversion
+.. automodule:: pytket.qir.conversion.api
+
+    .. autofunction:: pytket_to_qir
+    
+    .. autoclass:: QIRFormat
+
+    .. autoclass:: QIRProfile
+
+    .. autoexception:: ClassicalRegisterWidthError
+
+    .. autofunction:: check_circuit
+
+.. automodule:: pytket.qir.conversion.qirgenerator
+
+    .. autoclass:: AbstractQirGenerator
+
+        .. automethod:: circuit_to_module
+        .. automethod:: command_to_module
+        .. automethod:: record_output
+        .. automethod:: subcircuit_to_module
+        .. automethod:: conv_BarrierOp
+        .. automethod:: conv_CopyBitsOp
+        .. automethod:: conv_RangePredicateOp
+        .. automethod:: conv_SetBitsOp
+        .. automethod:: conv_WASMOp
+        .. automethod:: conv_ZZPhase
+        .. automethod:: conv_clexprop
+        .. automethod:: conv_conditional
+        .. automethod:: conv_measure
+        .. automethod:: conv_other
+        .. automethod:: conv_phasedx
+        .. automethod:: conv_tk2
+        .. automethod:: conv_zzmax
+        .. automethod:: get_azure_sar
+        .. automethod:: get_ssa_vars
+        .. automethod:: get_wasm_sar
+        .. automethod:: set_ssa_vars
+
+.. automodule:: pytket.qir.conversion.baseprofileqirgenerator
+
+    .. autoclass:: BaseProfileQirGenerator
+
+        .. automethod:: record_output
+        .. automethod:: conv_conditional
+        .. automethod:: conv_measure
+        .. automethod:: get_ssa_list
+        .. automethod:: get_ssa_vars
+        .. automethod:: set_ssa_vars
+
+.. automodule:: pytket.qir.conversion.profileqirgenerator
+
+    .. autoclass:: AdaptiveProfileQirGenerator
+
+        .. automethod:: record_output
+        .. automethod:: conv_conditional
+        .. automethod:: conv_measure
+        .. automethod:: get_ssa_list
+        .. automethod:: get_ssa_vars
+        .. automethod:: set_ssa_vars
+
+.. automodule:: pytket.qir.conversion.pytketqirgenerator
+
+    .. autoclass:: PytketQirGenerator
+
+        .. automethod:: record_output
+        .. automethod:: conv_conditional
+        .. automethod:: conv_measure
+        .. automethod:: get_ssa_vars
+        .. automethod:: set_ssa_vars
+
+.. automodule:: pytket.qir.conversion.azurebaseprofileqirgenerator
+
+    .. autoclass:: AzureBaseProfileQirGenerator
+
+        .. automethod:: record_output
+        .. automethod:: conv_measure
+
+.. automodule:: pytket.qir.conversion.azureprofileqirgenerator
+
+    .. autoclass:: AzureAdaptiveProfileQirGenerator
+
+        .. automethod:: record_output
+        .. automethod:: conv_measure
+
+.. automodule:: pytket.qir.conversion.module
+
+    .. autoclass:: tketqirModule
+
+.. automodule:: pytket.qir.conversion.gatesets
+
+    .. autoclass:: QirGate
+    .. autoclass:: CustomQirGate
+    .. autoclass:: CustomGateSet
+    .. autoclass:: FuncName
+    .. autoclass:: FuncNat
+    .. autoclass:: FuncSpec

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 0.24.1 (May 2025)
 -----------------
 
-* Store more information in `ClassicalRegisterWidthError`.
+* Store more information in :py:exc:`~.ClassicalRegisterWidthError`.
 
 0.24.0 (May 2025)
 -----------------
@@ -58,7 +58,7 @@ Changelog
 ---------------------
 
 * Updated pytket version requirement to 1.34.
-* Add support for pytket circuits containing `ClExprOp`.
+* Add support for pytket circuits containing :py:class:`~pytket.circuit.ClExprOp`.
 * Always check wasm files
 
 0.15.0 (October 2024)
@@ -85,15 +85,15 @@ Changelog
 * Updated pytket version requirement to 1.30.
 * updated pyqir version requirement to 0.10.3.
 * Update version requirements on dependencies, removing all upper bounds.
-* speed up conversion
-* add additional `check_circuit` function for checking the
+* Speed up conversion
+* Sdd additional :py:func:`~.check_circuit` function for checking the
   circuit before converting
 
 0.11.0 (May 2024)
 -----------------
 
 * Updated pytket version requirement to 1.28.
-* add support for BitWiseOp.ONE, BitWiseOp.ZERO in conversion
+* Add support for BitWiseOp.ONE, BitWiseOp.ZERO in conversion
 
 0.10.1 (April 2024)
 -------------------
@@ -115,20 +115,20 @@ Changelog
 --------------------
 
 * Updated pytket version requirement to 1.23.
-* updated pyqir version requirement to 0.10.0.
+* Updated pyqir version requirement to 0.10.0.
 
 0.6.0 (November 2023)
 ---------------------
 
 * Updated pytket version requirement to 1.22.
-* update measurement to write to register directly
-* remove unused ssa variables generated in output
+* Update measurement to write to register directly
+* Remove unused ssa variables generated in output
 
 0.5.0 (November 2023)
 ---------------------
 
-* updated pyqir version requirement to 0.9.0.
-* removed dependency of pyqir-generator, pyqir-evaluator and pyqir-parser
+* Updated pyqir version requirement to 0.9.0.
+* Removed dependency of pyqir-generator, pyqir-evaluator and pyqir-parser
 
 0.4.0 (October 2023)
 --------------------
@@ -137,16 +137,16 @@ Changelog
 
 0.3.0 (September 2023)
 ----------------------
-* update pytket version to 1.20
+* Update pytket version to 1.20
 
 0.2.0 (August 2023)
 -------------------
-* fix issue with integer in regular expression
-* add support for wasm in the conversion
-* new parameter to set the size of the int parameters of the registers in the qir generation
-* update pytket requirement to 1.19.0rc0
-* update the classical register handling to use i1* pointer
-* add simplification for RangePredicate in case of equal bounds
-* allow conditional circboxes in the circuit
-* add pytket to qir conversion
-* set pyqir version to 0.8.2
+* Fix issue with integer in regular expression
+* Add support for wasm in the conversion
+* New parameter to set the size of the int parameters of the registers in the qir generation
+* Update pytket requirement to 1.19.0rc0
+* Update the classical register handling to use i1* pointer
+* Add simplification for RangePredicate in case of equal bounds
+* Allow conditional circboxes in the circuit
+* Add pytket to qir conversion
+* Set pyqir version to 0.8.2

--- a/pytket/qir/__init__.py
+++ b/pytket/qir/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Quantinuum devices"""
-
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__
 from .conversion import QIRFormat, QIRProfile, pytket_to_qir

--- a/pytket/qir/conversion/__init__.py
+++ b/pytket/qir/conversion/__init__.py
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backends for processing pytket circuits with Quantinuum devices"""
-
 from .api import ClassicalRegisterWidthError, QIRFormat, QIRProfile, pytket_to_qir

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -206,8 +206,7 @@ def pytket_to_qir(  # noqa: PLR0911, PLR0912, PLR0913
         return populated_module.module.bitcode()
     elif qir_format == QIRFormat.STRING:
         return populated_module.module.ir()
-    else:
-        assert not "unsupported return type"  # type: ignore.
+    assert not "unsupported return type"  # type: ignore
     return None
 
 

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -70,7 +70,7 @@ class ClassicalRegisterWidthError(Exception):
         super().__init__(msg)
 
 
-def pytket_to_qir(  # noqa: PLR0912, PLR0913
+def pytket_to_qir(  # noqa: PLR0911, PLR0912, PLR0913
     circ: Circuit,
     name: str = "Generated from input pytket circuit",
     qir_format: QIRFormat = QIRFormat.BINARY,
@@ -182,7 +182,7 @@ def pytket_to_qir(  # noqa: PLR0912, PLR0913
             return bitcode
         if qir_format == QIRFormat.STRING:
             return result
-        assert not "unsupported return type"  # type: ignore  # noqa: RET503
+        assert not "unsupported return type"  # type: ignore
 
     elif qir_generator.has_wasm:
         wasm_sar_dict: dict[str, str] = qir_generator.get_wasm_sar()
@@ -200,14 +200,15 @@ def pytket_to_qir(  # noqa: PLR0912, PLR0913
             return bitcode
         if qir_format == QIRFormat.STRING:
             return result
-        assert not "unsupported return type"  # type: ignore  # noqa: RET503
+        assert not "unsupported return type"  # type: ignore
 
     elif qir_format == QIRFormat.BINARY:
         return populated_module.module.bitcode()
     elif qir_format == QIRFormat.STRING:
         return populated_module.module.ir()
     else:
-        assert not "unsupported return type"  # type: ignore  # noqa: RET503
+        assert not "unsupported return type"  # type: ignore.
+    return None
 
 
 def check_circuit(

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -78,7 +78,7 @@ def pytket_to_qir(  # noqa: PLR0912, PLR0913
     cut_pytket_register: bool = False,
     profile: QIRProfile = QIRProfile.PYTKET,
 ) -> str | bytes | None:
-    """converts given pytket circuit to qir
+    """Converts the given pytket :py:class:`~pytket._tket.circuit.Circuit` to qir
 
     :param circ: given circuit
     :param name: name for the qir module created

--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-public api for qir conversion from pytket
-"""
-
 from enum import Enum
 from typing import TYPE_CHECKING
 

--- a/pytket/qir/conversion/module.py
+++ b/pytket/qir/conversion/module.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module defines an extension for the PyQir SimpleModule
-for the needs of generating QIR from Pytket circuits.
-"""
-
 from pyqir import BasicQisBuilder, SimpleModule
 
 from pytket.wasm import WasmFileHandler

--- a/pytket/qir/conversion/pytketqirgenerator.py
+++ b/pytket/qir/conversion/pytketqirgenerator.py
@@ -36,9 +36,9 @@ from .qirgenerator import (
 
 class PytketQirGenerator(AbstractQirGenerator):
     """Generates QIR from a pytket circuit in line with the pytket profile.
-    This profile uses the functions `get_creg_bit`, `set_creg_bit`,
-    `set_creg_to_int`, `create_creg`, `get_int_from_creg` and
-    `mz_to_creg_bit` for the handling of the classical registers.
+    This profile uses the functions ``get_creg_bit``, ``set_creg_bit``,
+    ``set_creg_to_int``, ``create_creg``, ``get_int_from_creg`` and
+    ``mz_to_creg_bit`` for the handling of the classical registers.
     The other aspects of the QIR file are identical to the adaptive profile.
     """
 

--- a/pytket/qir/conversion/qirgenerator.py
+++ b/pytket/qir/conversion/qirgenerator.py
@@ -968,7 +968,7 @@ class AbstractQirGenerator:
 
     @abc.abstractmethod
     def record_output(self) -> None:
-        """function to record the output"""
+        """Function to record the output"""
 
     def circuit_to_module(
         self,


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
