### PR TITLE
Add gateset check to check circuit

### DIFF
--- a/pytket/qir/conversion/api.py
+++ b/pytket/qir/conversion/api.py
@@ -17,14 +17,16 @@ from typing import TYPE_CHECKING
 
 import pyqir
 
-from pytket.circuit import Circuit
+from pytket.circuit import Circuit, OpType
 from pytket.passes import (
     scratch_reg_resize_pass,
 )
+from pytket.predicates import GateSetPredicate
 
 from .azurebaseprofileqirgenerator import AzureBaseProfileQirGenerator
 from .azureprofileqirgenerator import AzureAdaptiveProfileQirGenerator
 from .baseprofileqirgenerator import BaseProfileQirGenerator
+from .gatesets import PYQIR_GATES
 from .module import tketqirModule
 from .profileqirgenerator import AdaptiveProfileQirGenerator
 from .pytketqirgenerator import PytketQirGenerator
@@ -213,6 +215,7 @@ def pytket_to_qir(  # noqa: PLR0911, PLR0912, PLR0913
 def check_circuit(
     circuit: Circuit,
     int_type: int = 64,
+    gate_set: set[OpType] = PYQIR_GATES.base_gateset,
 ) -> None:
     """Checks the validity of the circuit.
 
@@ -221,7 +224,9 @@ def check_circuit(
 
     :param circuit: given circuit
     :param int_type: integer bit width (32 or 64)
-    :raises ValueError: with a suggestion on how to resolve the problems
+    :param gate_set: set of OpTypes to use to check that all gates can be converted
+    :raises ClassicalRegisterWidthError: for problems with classical register width
+    :raises ValueError: for other circuit problems
     """
     if len(circuit.q_registers) > 1 or (
         len(circuit.q_registers) == 1 and circuit.q_registers[0].name != "q"
@@ -247,3 +252,7 @@ def check_circuit(
     for b in {b.reg_name for b in circuit.bits}:
         if b not in set_circ_register:
             raise ValueError(f"Used register {b} in not a valid register")
+
+    gate_set_predicate = GateSetPredicate(gate_set)
+    if not gate_set_predicate.verify(circuit):
+        raise ValueError(f"Circuit contains gates that can't be converted to QIR. Supported gates: {gate_set}")

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -17,7 +17,7 @@ import pyqir
 import pytest
 from utilities import run_qir_gen_and_check  # type: ignore
 
-from pytket.circuit import Bit, Circuit
+from pytket.circuit import Bit, Circuit, OpType
 from pytket.passes import FlattenRelabelRegistersPass
 from pytket.qir.conversion.api import (
     ClassicalRegisterWidthError,
@@ -128,6 +128,18 @@ def test_pytket_api_creg_5() -> None:
     FlattenRelabelRegistersPass("q").apply(circ)
 
     check_circuit(circ)
+
+
+def test_pytket_api_unsupported_gate() -> None:
+    circ = Circuit(3)
+    circ.H(0)
+
+    circ.ECR(0, 1)  # Currently, the default gateset does not support this.
+    with pytest.raises(ValueError):
+        check_circuit(circ)
+
+    # However, a custom gateset could support it.
+    check_circuit(circ, gate_set={OpType.H, OpType.ECR})
 
 
 def test_pytket_qir_module() -> None:


### PR DESCRIPTION
# Description

Add an extra test to `check_circuit` to make sure the circuit only contains gates that can be converted to QIR.

It takes a set of supported pytket OpTypes, which defaults to `PYQIR_GATES.base_gateset`.

Also updated the docstring for `check_circuit()` to list both the exceptions that can be raised.

# Related issues

None that I know of.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
